### PR TITLE
Reduce hubot fun

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -4,9 +4,7 @@
   "hubot-heroku-keepalive",
   "hubot-google-images",
   "hubot-google-translate",
-  "hubot-pugme",
   "hubot-maps",
   "hubot-redis-brain",
-  "hubot-rules",
-  "hubot-shipit"
+  "hubot-rules"
 ]


### PR DESCRIPTION
This commit removes the `shipit` and `pugme` plugins. They're way too much fun.
