### PR TITLE
Remove plugins we don't need yet

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -2,11 +2,6 @@
   "hubot-diagnostics",
   "hubot-help",
   "hubot-heroku-keepalive",
-  "hubot-google-images",
-  "hubot-google-translate",
-  "hubot-pugme",
-  "hubot-maps",
   "hubot-redis-brain",
-  "hubot-rules",
-  "hubot-shipit"
+  "hubot-rules"
 ]

--- a/package.json
+++ b/package.json
@@ -7,16 +7,11 @@
   "dependencies": {
     "hubot": "^2.16.0",
     "hubot-diagnostics": "0.0.1",
-    "hubot-google-images": "^0.2.2",
-    "hubot-google-translate": "^0.2.0",
     "hubot-help": "^0.1.2",
     "hubot-heroku-keepalive": "^1.0.0",
-    "hubot-maps": "0.0.2",
-    "hubot-pugme": "^0.1.0",
     "hubot-redis-brain": "0.0.3",
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.16.2",
-    "hubot-shipit": "^0.2.0",
     "hubot-slack": "^3.4.1"
   },
   "engines": {


### PR DESCRIPTION
We want to start off with the deployment stuff, not other chatty stuff.
We can add that later.
