### PR TITLE
Add hubot standup

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -3,5 +3,6 @@
   "hubot-help",
   "hubot-heroku-keepalive",
   "hubot-pager-me",
-  "hubot-redis-brain"
+  "hubot-redis-brain",
+  "hubot-standup-alarm"
 ]

--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,7 +1,7 @@
 [
-  "hubot-pager-me",
   "hubot-diagnostics",
   "hubot-help",
   "hubot-heroku-keepalive",
+  "hubot-pager-me",
   "hubot-redis-brain"
 ]

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "hubot-pager-me": "^2.1.6",
     "hubot-redis-brain": "0.0.3",
     "hubot-scripts": "^2.16.2",
-    "hubot-slack": "^3.4.1"
+    "hubot-slack": "^3.4.1",
+    "hubot-standup-alarm": "0.0.7"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
From readme:

> In a chat room, you can ask Hubot to create a standup at a specific
> time. From then on, at that time every weekday, Hubot will post in the
> chat room reminding you to have your standup. You can create as many
> standups as you like, across as many rooms as you like.

https://github.com/hubot-scripts/hubot-standup-alarm

I've configured `HUBOT_STANDUP_PREPEND` to be `@here`, so that only present members of the channel get notified.
