### PR TITLE
Revert "Add heroku-deploy-notifier"

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,7 +1,6 @@
 [
   "hubot-diagnostics",
   "hubot-help",
-  "hubot-heroku-deploy-notifier",
   "hubot-heroku-keepalive",
   "hubot-pager-me",
   "hubot-redis-brain",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "hubot": "^2.16.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-help": "^0.1.2",
-    "hubot-heroku-deploy-notifier": "^0.1.4",
     "hubot-heroku-keepalive": "^1.0.0",
     "hubot-pager-me": "^2.1.6",
     "hubot-redis-brain": "0.0.3",


### PR DESCRIPTION
Reverts alphagov/gds-hubot#8. The plugin is not working, probably because it's pretty old.
