### PR TITLE
Upgrade hubot-standup-alarm to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "hubot-redis-brain": "0.0.3",
     "hubot-scripts": "^2.16.2",
     "hubot-slack": "^3.4.1",
-    "hubot-standup-alarm": "0.0.7",
+    "hubot-standup-alarm": "0.1.0",
     "hubot-github-repo-event-notifier": ">= 0.0.0"
   },
   "engines": {


### PR DESCRIPTION
Our team (PaaS) would like the ability to include our Hangouts URL in the
stnadup notification. This should be possible using the following command,
but Hubot on our Slack currently ignores it:

```
hubot create standup hh:mm at location/url
```

My theory is that the version of the plugin we're using predates when the
functionality was added [0]. This is hard to confirm though because the repo
doesn't have tags or a `package.json` for version 0.7.0, it went straight
from 0.6.0 to 0.1.0 [1].

[0] hubot-scripts/hubot-standup-alarm@81e3718e0fb7d489ac47f224ab530e59ffae5242
[1] hubot-scripts/hubot-standup-alarm@32226631e080c2958fb168db9c1feea81da3eab8

I'm also not sure how I can test this. So basically I hope this fixes the
problem and doesn't introduce any others :D