### PR TITLE
Remove business-support-finder

### DIFF
--- a/scripts/security-audit-finding-things.sh
+++ b/scripts/security-audit-finding-things.sh
@@ -15,7 +15,6 @@ check_repo() {
 }
 
 repos=(
-  business-support-finder
   collections
   collections-publisher
   content-tagger


### PR DESCRIPTION
This commit removes business-support-finder, which has been replaced with finder-frontend.

Trello: https://trello.com/c/9O34PdXb/547-remove-business-support-finder-application