### PR TITLE
Teach hubot which team owns which GOV.UK applications

### DIFF
--- a/scripts/govuk_app_owners.coffee
+++ b/scripts/govuk_app_owners.coffee
@@ -1,0 +1,12 @@
+# This script teaches Hubot to answer questions like "Who owns Collections Publisher?"
+# and "Who owns publishing-api?"
+module.exports = (robot) ->
+  robot.hear /who owns (.*)\?/i, (res) ->
+    # Best guess of the intended application.
+    application = res.match[1].replace(' ', '-').toLowerCase()
+
+    robot.http("https://docs.publishing.service.gov.uk/apps/#{application}.json")
+      .get() (err, response, body) ->
+        if response.statusCode == 200
+          data = JSON.parse(body)
+          res.reply "#{application} is owned by #{data.team}"


### PR DESCRIPTION
This script teaches Hubot to answer questions like "Who owns Collections Publisher?" and "Who owns publishing-api?". Made possible by https://github.com/alphagov/govuk-developer-docs/pull/328.