### PR TITLE
Upgrade Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "hubot-github-repo-event-notifier": ">= 0.0.0"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": "4.8.4"
   }
 }


### PR DESCRIPTION
To counter https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/. 4.8.4 is the lowest non-vulnerable version.

@alecgibson 