### PR TITLE
Update product ownership to refer to Product Manager

### DIFF
--- a/scripts/govuk_app_owners.coffee
+++ b/scripts/govuk_app_owners.coffee
@@ -10,4 +10,4 @@ module.exports = (robot) ->
       .get() (err, response, body) ->
         if response.statusCode == 200
           data = JSON.parse(body)
-          res.reply "#{data.app_name} is owned by #{data.team}"
+          res.reply "#{data.app_name} is owned by #{data.product_manager} (#{data.team})"


### PR DESCRIPTION
The current state of affairs is that products are owned by product managers, and products follow them when they change team. The team information still seems useful so we leave it in.

Refers to information here -> https://docs.publishing.service.gov.uk/apps/by-team.html

One thing I wasn't sure about is whether this will notify the product managers in Slack every time someone uses this? Because the text will presumably be something like

```
Q: Who owns specific app?
A: specific app is owned by @some_user (#some_team)
```

However it looks like it doesn't provide a proper link for the team either, so I think it won't notify the user (which seems preferable).