### PR TITLE
Do not notify app product managers

### DIFF
--- a/scripts/govuk_app_owners.coffee
+++ b/scripts/govuk_app_owners.coffee
@@ -10,4 +10,4 @@ module.exports = (robot) ->
       .get() (err, response, body) ->
         if response.statusCode == 200
           data = JSON.parse(body)
-          res.reply "#{data.app_name} is owned by #{data.product_manager} (#{data.team})"
+          res.reply "#{data.app_name} is owned by `#{data.product_manager}` (#{data.team})"


### PR DESCRIPTION
We strip the '@' character from the product manager's name as otherwise it would notify them in Slack which could get annoying for them.