### PR TITLE
Downgrade Hubot to 2.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "GOV.UK Dev <govuk-dev@digital.cabinet-office.gov.uk>",
   "description": "Your friendly government robot.",
   "dependencies": {
-    "hubot": "^3.1.1",
+    "hubot": "^2.19.0",
     "hubot-diagnostics": "^1.0.0",
     "hubot-github-repo-event-notifier": "^1.8.1",
     "hubot-help": "^1.0.1",


### PR DESCRIPTION
This commit downgrades just the Hubot package to `2.19.0`, which is the last of the `2.x` series. This is because the Slack integration doesn’t yet support the `3.x` series.